### PR TITLE
Resolve build issues with mkdocs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM squidfunk/mkdocs-material:6.2.4
+FROM python:3
+
 RUN pip install --no-cache-dir \
+        'mkdocs' \
+        'mkdocs-material==6.2.4' \
         'mkdocs-awesome-pages-plugin>=2.2.1' \
         'mkdocs-git-revision-date-localized-plugin>=0.4' \
         'mkdocs-minify-plugin>=0.3' \
         'mkdocs-redirects>=1.0' \
         'mkdocs-rss-plugin>=0.6.1'
+
+WORKDIR /docs
+
+EXPOSE 8000
+
+ENTRYPOINT ["mkdocs"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
Per a note[1] on the mkdocs-material page, it seems the way this is
built doesn't allow for a correct build pipeline as it was ignoring any
changes in the custom_dir.

This should hopefully resolve and correctly build the docs.

[1] https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure