### PR TITLE
Bump mkdocs-material to 8.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3
 
 RUN pip install --no-cache-dir \
         'mkdocs' \
-        'mkdocs-material==6.2.4' \
+        'mkdocs-material==8.0.0' \
         'mkdocs-awesome-pages-plugin>=2.2.1' \
         'mkdocs-git-revision-date-localized-plugin>=0.4' \
         'mkdocs-minify-plugin>=0.3' \


### PR DESCRIPTION
Would still be worth testing, image `docker.pkg.github.com/elken/docs-image/docs-image` has the changes implemented if someone wants to verify the changes before merging this in.

Also [changeset](https://github.com/squidfunk/mkdocs-material/compare/6.2.4..8.0.0) (it's a big one...)